### PR TITLE
Fix issue with decoding enum in protobuf3

### DIFF
--- a/c_src/ep_decoder.c
+++ b/c_src/ep_decoder.c
@@ -869,6 +869,16 @@ fill_default(ErlNifEnv *env, ep_spot_t *spot)
                 break;
             }
 
+        } else if (field->type == field_enum) {
+            ep_enum_field_t    *efield;
+            efield = field->sub_node->v_fields;
+            if (efield == NULL) {
+                *t++ = state->integer_zero;
+            } else {
+                *t++ = efield->name;
+            }
+            // TODO(murali@): ensure this runs only for proto3.
+
         } else {
             *t++ = state->atom_undefined;
         }


### PR DESCRIPTION
- In protobuf3: enums are by default assigned to the first value.
- Our nif decoder: assigns undefined to enum in this case.
- This diff now fixes it. Added a todo to check if the version is proto3.
- I'll push it upstream after I do the check for proto3 properly.