### PR TITLE
Fill default value for boolean

### DIFF
--- a/c_src/ep_decoder.c
+++ b/c_src/ep_decoder.c
@@ -879,6 +879,10 @@ fill_default(ErlNifEnv *env, ep_spot_t *spot)
             }
             // TODO(murali@): ensure this runs only for proto3.
 
+        } else if (field->type == field_bool) {
+            *t++ = state->atom_false;
+            // TODO(murali@): ensure this runs only for proto3.
+
         } else {
             *t++ = state->atom_undefined;
         }


### PR DESCRIPTION
- proto3 leaves out default values when encoding the value.
- false is the default value for protobufs.
- this sets our decoder to set the default value for boolean fields.