### PR TITLE
Adding custom changes (#25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
   pull_request:
     branches:
       - master
-  schedule:
-    - cron: '0 10 * * *' # Once per day at 10am UTC
 
 jobs:
   ubuntu:
@@ -17,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        otp: ["22", "23", "24"]
+        otp: ["23", "24"]
       fail-fast: false
 
     container:
@@ -28,38 +26,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Checkout Proper
-        uses: actions/checkout@v2
-        with:
-          repository: proper-testing/proper
-          path: "./proper"
-      - name: Run test
-        run: |
-          make
-          make tests
-
-  macos:
-    name: Test on MacOS
-    runs-on: macos-latest
-
-    strategy:
-      matrix:
-        otp: ["22", "23", "24"]
-      fail-fast: false
-
-    env:
-      ERL_LIBS: './'
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Brew Version Check
-        run: brew --version
-      - name: Keep Brew Fresh
-        run: brew update
-      - name: Install Erlang
-        run: brew install erlang@${{ matrix.otp }}
-      - name: Brew Link
-        run: brew link erlang@${{ matrix.otp }} --force
       - name: Checkout Proper
         uses: actions/checkout@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,4 @@ cmake-build-debug
 deps
 ebin
 log
-rebar.lock
 rebar3

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -14,34 +14,29 @@ C_SRC_DIR = $(CURDIR)
 C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so
 
 # System type and C compiler/flags.
-
+MACHINE_SYS := $(shell uname -m)
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
-    ARCH_SYS := $(shell uname -p)
-    ifeq ($(ARCH_SYS), arm)
-        ARCH_NAME := arm64
-    else
-        ARCH_NAME := x86_64
-    endif
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch $(ARCH_NAME) -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -arch $(ARCH_NAME) -finline-functions -Wall
-	LDFLAGS ?= -arch $(ARCH_NAME) -flat_namespace -undefined suppress
+	CFLAGS ?= -O3 -std=c99 -arch $(MACHINE_SYS) -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -arch $(MACHINE_SYS) -finline-functions -Wall
+	LDFLAGS = -arch $(MACHINE_SYS) -flat_namespace -undefined suppress -bundle
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
 	CXXFLAGS ?= -O3 -finline-functions -Wall
+	LDFLAGS = -shared
 else ifeq ($(UNAME_SYS), Linux)
 	CC ?= gcc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
 	CXXFLAGS ?= -O3 -finline-functions -Wall
+	LDFLAGS = -shared
 endif
 
 CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 
 LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lei -lpthread
-LDFLAGS += -shared
 
 # Verbosity.
 

--- a/c_src/enif_protobuf.c
+++ b/c_src/enif_protobuf.c
@@ -20,6 +20,18 @@ make_atom(ErlNifEnv *env, const char *name)
     return enif_make_atom(env, name);
 }
 
+
+char*
+get_atom(ErlNifEnv *env, ERL_NIF_TERM term, char *buf, unsigned size)
+{
+    if (enif_get_atom(env, term, buf, size, ERL_NIF_LATIN1)) {
+        return buf;
+    }
+    return NULL;
+}
+
+
+
 /*
  * nif library callbacks
  */

--- a/c_src/enif_protobuf.h
+++ b/c_src/enif_protobuf.h
@@ -337,4 +337,7 @@ _calloc(size_t nmemb, size_t size)
 ERL_NIF_TERM
 make_atom(ErlNifEnv *env, const char *name);
 
+char*
+get_atom(ErlNifEnv *env, ERL_NIF_TERM term, char *buf, unsigned size);
+
 #endif

--- a/c_src/ep_decoder.c
+++ b/c_src/ep_decoder.c
@@ -104,6 +104,38 @@ unpack_int32(ErlNifEnv *env, ep_dec_t *dec, ERL_NIF_TERM *term)
 }
 
 static inline ERL_NIF_TERM
+unpack_int64_as_bin(ErlNifEnv *env, ep_dec_t *dec, ERL_NIF_TERM *term)
+{
+    int32_t     shift = 0, left = 10;
+    int64_t     val = 0;
+    ErlNifBinary    bin;
+    char valString[32];
+
+    while (left && dec->p < dec->end) {
+
+        val |= ((uint64_t) (*(dec->p) & 0x7f) << shift);
+        if ((*(dec->p)++ & 0x80) == 0) {
+            size_t size = 0;
+            while (val > 0) {
+                valString[31 - size] = (val % 10) + '0';
+                size++;
+                val /= 10;
+            }
+            if (!enif_alloc_binary(size, &bin)) {
+                return_error(env, dec->term);
+            }
+            memcpy(bin.data, valString + 32 - size, size);
+            *term = enif_make_binary(env, &bin);
+            return RET_OK;
+        }
+        shift += 7;
+        left--;
+    }
+
+    return_error(env, dec->term);
+}
+
+static inline ERL_NIF_TERM
 unpack_fixed32(ErlNifEnv *env, ep_dec_t *dec, ERL_NIF_TERM *term)
 {
     uint32_t    val = 0;
@@ -538,7 +570,11 @@ unpack_element_packed(ErlNifEnv *env, ep_dec_t *dec, ERL_NIF_TERM *term, ep_fiel
             break;
 
         case field_int64:
-            check_ret(ret, unpack_int64(env, dec, &head));
+            if (field->ebin == TRUE) {
+                check_ret(ret, unpack_int64_as_bin(env, dec, &head));
+            } else {
+                check_ret(ret, unpack_int64(env, dec, &head));
+            }
             break;
 
         case field_uint64:
@@ -629,7 +665,11 @@ unpack_field(ErlNifEnv *env, ep_dec_t *dec, ERL_NIF_TERM *term, wire_type_e wire
         if (wire_type != WIRE_TYPE_VARINT) {
             return pass_field(env, dec, wire_type);
         }
-        check_ret(ret, unpack_int64(env, dec, term));
+        if (field->ebin == TRUE) {
+            check_ret(ret, unpack_int64_as_bin(env, dec, term));
+        } else {
+            check_ret(ret, unpack_int64(env, dec, term));
+        }
         break;
 
     case field_uint64:
@@ -879,6 +919,34 @@ fill_default(ErlNifEnv *env, ep_spot_t *spot)
                 break;
             }
 
+        } else if (field->type == field_enum) {
+            ep_enum_field_t    *efield;
+            efield = field->sub_node->v_fields;
+            if (efield == NULL) {
+                *t++ = enif_make_int(env, 0);
+            } else {
+                *t++ = efield->name;
+            }
+            // TODO(murali@): ensure this runs only for proto3.
+
+        } else if (field->type == field_bool) {
+            *t++ = state->atom_false;
+            // TODO(murali@): ensure this runs only for proto3.
+
+        } else if (field->type == field_int32 || field->type == field_int64) {
+            if (field->ebin == TRUE) {
+                // Using state->binary_nil is causing a crash - so we have to make our own binary here.
+                ErlNifBinary bin;
+                if (!enif_alloc_binary(0, &bin)) {
+                    *t++ = enif_make_int(env, 0);
+                } else {
+                    *t++ = enif_make_binary(env, &bin);
+                }
+            } else {
+                *t++ = enif_make_int(env, 0);
+            }
+        }  else if (field->type == field_float || field->type == field_double) {
+            *t++ = enif_make_double(env, 0.0);
         } else {
             *t++ = state->atom_undefined;
         }
@@ -941,7 +1009,6 @@ decode(ErlNifEnv *env, ep_tdata_t *tdata, ep_node_t *node)
             spot->pos = 0;
             if (spot->field && spot->field->is_oneof) {
                 term = enif_make_tuple_from_array(env, spot->t_arr, (unsigned) (spot->t_used));
-                term = enif_make_tuple2(env, spot->field->name, term);
             } else if (spot->node && spot->node->n_type == node_map) {
                 term = enif_make_tuple_from_array(env, spot->t_arr + 1, (unsigned) (spot->t_used - 1));
             } else {

--- a/c_src/ep_node.h
+++ b/c_src/ep_node.h
@@ -26,6 +26,7 @@ struct ep_field_s {
     uint32_t            proto_v;
     uint32_t            is_oneof;
     uint32_t            packed;
+    uint32_t            ebin;
 };
 
 struct ep_fnum_field_s {
@@ -71,6 +72,9 @@ stack_ensure(ErlNifEnv *env, ep_stack_t *stack, ep_spot_t **spot);
 
 int
 get_field_compare_name(const void *a, const void *b);
+
+int
+get_field_compare_sub_name(const void *a, const void *b);
 
 int
 get_map_field_compare_fnum(const void *a, const void *b);

--- a/rebar.config
+++ b/rebar.config
@@ -8,25 +8,26 @@
     {"", compile, "escript enc compile"}
 ]}.
 
+{deps, [
+    {gpb, ".*", {git, "https://github.com/HalloAppInc/gpb.git", {tag, "h1.2"}}}
+]}.
+
+{erl_opts, [debug_info]}.
+
+{pre_hooks, [
+    {"(linux|darwin|solaris)", compile, "make -C c_src"},
+    {"(freebsd|openbsd)", compile, "gmake -C c_src"},
+    {"", compile, "escript enc compile"}
+]}.
+
 {post_hooks, [
     {"(linux|darwin|solaris)", clean, "make -C c_src clean"},
     {"(freebsd|openbsd)", clean, "gmake -C c_src clean"},
-    {"", clean, "escript enc clean"}
-]}.
+    {"", clean, "escript enc clean"}]}.
 
 {eunit_opts, [
     verbose,
-    {report,
-        {
-            eunit_surefire,
-            [{dir, "./_build/test"}]
-        }}
-]}.
-
-{profiles, [
-    {test, [
-        {deps, [
-            {gpb, ".*", {git, "https://github.com/tomas-abrahamsson/gpb.git", {branch, "master"}}}
-        ]}
-    ]}
+    {report, {
+        eunit_surefire, [{dir, "./_build/test"}]
+    }}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,4 @@
+[{<<"gpb">>,
+  {git,"https://github.com/HalloAppInc/gpb.git",
+       {ref,"a692fd85c381fb2da17b8022ebd5cf6657a15dc5"}},
+  0}].

--- a/test/ep_tests.erl
+++ b/test/ep_tests.erl
@@ -73,29 +73,27 @@ nested_oneof_test() ->
         {{msg, 'ChildLink'}, [
             #field{name = name, fnum = 2, rnum = 2, type = bytes, occurrence = required, opts = []}
         ]},
-        {{msg, 'FileChildren'}, [
+        {{msg, 'pb_FileChildren'}, [
             #field{name = child_links, fnum = 1, rnum = 2, type = {msg, 'ChildLink'}, occurrence = repeated, opts = []}
         ]},
-        {{msg, 'FuseResponse'}, [
+        {{msg, 'pb_FuseResponse'}, [
             #gpb_oneof{name = fuse_response, rnum = 2, fields = [
-                #field{name = file_children, fnum = 3, rnum = 2, type = {msg, 'FileChildren'}, occurrence = optional, opts = []},
+                #field{name = file_children, fnum = 3, rnum = 2, type = {msg, 'pb_FileChildren'}, occurrence = optional, opts = []},
                 #field{name = xattr, fnum = 13, rnum = 2, type = bytes, occurrence = optional, opts = []}
             ]}
         ]},
         {{msg, 'ServerMessage'}, [
             #gpb_oneof{name = message_body, rnum = 2, fields = [
-                #field{name = fuse_response, fnum = 15, rnum = 2, type = {msg, 'FuseResponse'}, occurrence = optional, opts = []}
+                #field{name = fuse_response, fnum = 15, rnum = 2, type = {msg, 'pb_FuseResponse'}, occurrence = optional, opts = []}
             ]}
         ]}
     ]),
     Msg = {'ServerMessage',
-        {fuse_response,
-            {'FuseResponse',
-                {file_children,
-                    {'FileChildren', [{'ChildLink', <<"1">>}]}
+            {'pb_FuseResponse',
+                    {'pb_FileChildren', [{'ChildLink', <<"1">>}]}
                 }
-            }
-        }
+
+
     },
     Bin = enif_protobuf:encode(Msg),
     Msg = enif_protobuf:decode(Bin, 'ServerMessage').


### PR DESCRIPTION
* Make oneof fields to be the value directly (#2)

* Make oneof fields to be the value directly

- oneof fields now must directly be the value.
- In addition to that, the variable type must match the record type.
- We extract variable name from the record name and then search for it.
- This will now always enforce the restriction that the variable name must match the message name in the protobuf definitions.

* Fix oneof_field to search based on type (#5)

* Fix oneof_field to search based on type

- I went through the code and realized that this variable node->fields is sorted different for different fields.
- Meaning it is sorted based on numbers for enums, it is sorted based on variable names for oneof fields, it is sorted based on message numbers for other fields.
- So, I went ahead and updated it to sort the field based on types and now we can compare them based on the type.
- No more restrictions of variable name matching the type name.
- The only restriction we'll have is: we cant have two fields of the same type in a oneof field: which is quite reasonable and nice for our usecase.

* Fill default value for boolean (#6)

- proto3 leaves out default values when encoding the value.
- false is the default value for protobufs.
- this sets our decoder to set the default value for boolean fields.

* Use HA's gpb

* Fix default value for int32,int64 and float values (#8)

- updated decoder to return default values for these integers and float fields instead of undefined.
- proto3 follows this convention.
- fixing this now, that we are getting rid of the parsers soon.

* Update nif to work with custom field option - ebin (#9)

* Update nif to work with custom field option - ebin

- update nif code to work with our custom field option - ebin.
- ebin when set to true on a field - will be encoded as integer from a binary.
- when decoding - it will decode the integer back to a binary.
- this will help us getting rid of translating uids to binaries.
- because currently uids are int64 in protobuf and binaries in erlang code.
- we also repeated fields and undefined as well.
- note that when value = 0 for these ebin fields - binary will be <<>>.

* Use own function instead of atol - causing issues

* Update to work with erl23 (#10)

* Update to work with erl23

- update to work with erlang23.

* Merge with upstream repo (#14)

* Upgrade to use rebar3
* Adds CI
* Remove unused proto files

* Fix to makefile (#15)

When updating the ejabberd makefile, I ran into an issue compiling this library.

The fix I implemented is outlined here: http://erlang.org/pipermail/erlang-questions/2011-June/059679.html

* fix makefile for M1 mac

Was hard-coded to compile for x86 on mac, now compiles for machine type dynamically

* Fix random segfault when loading cache (#23)

* Fix oneof fields to work properly for basic data types (#24)

- oneof fields was not working properly for non-message types like int64, bytes, string etc.
- erlang pb libraries in general set the oneof field values to be a tuple with the varname followed by the actual value.
- this is very inconvenient when we write the actual record in erlang code.
- so we made changes to set the oneof field to be the value directly without the variable name.
- changes for that are here: https://github.com/HalloAppInc/enif_protobuf/pull/5 and https://github.com/HalloAppInc/enif_protobuf/pull/2
- this breaks adding basic types as part of oneof because it will be hard to distinguish which field was set.
- so we need to go back to using the variable name for basic types.
- for basic field types: value must be set to {var_name, actual_field_value}
- for message field types: value must be set to the record directly.
- tested this and works well now.

* fixes after rebasing

* replace omit condition for pack_bin_as_int64 Currently proto_v is set to 2 for ejabberd and gpb marks fields as optional by default, so this
case should never run for us;
still good to be consistent with the rest of the file.

Co-authored-by: Murali Balusu <58709405+balusu-murali@users.noreply.github.com>
Co-authored-by: Vipin <vipin211@hotmail.com>
Co-authored-by: murali <murali@halloapp.com>
Co-authored-by: kennedyjosh <32585114+kennedyjosh@users.noreply.github.com>
Co-authored-by: loukiano <luke@halloapp.com>
Co-authored-by: Luke Arnold <31359286+loukiano@users.noreply.github.com>
Co-authored-by: Thomas Neill <thomas@Thomass-MacBook-Pro.local>